### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 ## Documentation
 
-Documentation of ArchiBoT is available on our **[wiki](https://github.com/JustArchi/ArchiBoT/wiki)**. It covers entire usage from user's perspective.
+Documentation of ArchiBoT is available on our **[wiki](https://github.com/JustArchiNET/ArchiBot/wiki)**. It covers entire usage from user's perspective.
 
 ---
 
 ### Code
 
-ArchiBoT is not open-source by definition, although there are many "public" modules that are being hosted in this repo. Those can be freely forked, improved and re-used based on our **[license](https://github.com/JustArchi/ArchiBoT/blob/master/LICENSE-2.0.txt)**. We also accept PRs and issues for them.
+ArchiBoT is not open-source by definition, although there are many "public" modules that are being hosted in this repo. Those can be freely forked, improved and re-used based on our **[license](LICENSE-2.0.txt)**. We also accept PRs and issues for them.
 
 ---
 
 ### Public modules
 
-- **[AI brain](https://github.com/JustArchi/ArchiBoT/tree/master/Brain)**
+- **[AI brain](Brain)**


### PR DESCRIPTION
The repository seems to have been moved and renamed. The links in the README lead to non-existing pages.

This change fixes the links. The two tree path links are changed to relative path specifiers.